### PR TITLE
[#466] 채팅 메시지 저장로직 변경 및 캐싱 구현

### DIFF
--- a/backend/src/main/java/com/team5/secondhand/application/item/controller/v1/dto/request/ItemFilteredSlice.java
+++ b/backend/src/main/java/com/team5/secondhand/application/item/controller/v1/dto/request/ItemFilteredSlice.java
@@ -4,9 +4,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.Size;
+import lombok.ToString;
 
 @Getter
 @RequiredArgsConstructor
+@ToString
 public class ItemFilteredSlice {
     @Size(min = 0)
     private final int page;

--- a/backend/src/main/java/com/team5/secondhand/application/item/service/ItemPostService.java
+++ b/backend/src/main/java/com/team5/secondhand/application/item/service/ItemPostService.java
@@ -8,18 +8,23 @@ import com.team5.secondhand.application.item.repository.ItemRepository;
 import com.team5.secondhand.application.member.domain.Member;
 import com.team5.secondhand.application.member.exception.UnauthorizedException;
 import com.team5.secondhand.application.region.domain.Region;
+import com.team5.secondhand.global.config.CacheKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = CacheKey.ITEM)
 public class ItemPostService {
 
     private final ItemRepository itemRepository;
 
     @Transactional
+    @CacheEvict(allEntries = true)
     public Long postItem(Item item, Member seller, Region region, String thumbnailUrl) {
         item.updateThumbnail(thumbnailUrl);
         itemRepository.save(item.owned(seller, region));
@@ -43,7 +48,7 @@ public class ItemPostService {
         return itemRepository.updateStatus(id, status) == 1;
     }
 
-    @CacheEvict(value = "menu", allEntries = true)
+    @CacheEvict(allEntries = true)
     public void deleteById(Long id) {
         itemRepository.deleteById(id);
     }

--- a/backend/src/main/java/com/team5/secondhand/application/item/service/ItemReadService.java
+++ b/backend/src/main/java/com/team5/secondhand/application/item/service/ItemReadService.java
@@ -36,6 +36,7 @@ public class ItemReadService {
     private final CheckMemberLikedUsecase checkMemberLiked;
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "items", key = "#request.toString() + '::' + #region.id")
     public ItemList getItemList(ItemFilteredSlice request, Region region, MemberDetails loginMember) {
         Pageable pageable = PageRequest.of(request.getPage() , PAGE_SIZE, Sort.by("id").descending());
 

--- a/backend/src/main/java/com/team5/secondhand/application/region/service/RegionService.java
+++ b/backend/src/main/java/com/team5/secondhand/application/region/service/RegionService.java
@@ -3,7 +3,9 @@ package com.team5.secondhand.application.region.service;
 import com.team5.secondhand.application.region.domain.Region;
 import com.team5.secondhand.application.region.exception.NotValidRegionException;
 import com.team5.secondhand.application.region.repository.RegionRepository;
+import com.team5.secondhand.global.config.CacheKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.annotation.Cacheable;
@@ -13,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@CacheConfig(cacheNames = CacheKey.REGION)
 @RequiredArgsConstructor
 public class RegionService implements GetValidRegionsUsecase {
 
@@ -22,6 +25,7 @@ public class RegionService implements GetValidRegionsUsecase {
     @Transactional(readOnly = true)
     public Map<Long, Region> getRegions(List<Long> ids) throws NotValidRegionException {
         Map<Long, Region> regions = new HashMap<>();
+
         for (Region region : regionRepository.findAllById(ids)) {
             regions.put(region.getId(), region);
         }
@@ -35,12 +39,13 @@ public class RegionService implements GetValidRegionsUsecase {
 
     @Override
     @Transactional(readOnly = true)
-    @Cacheable(value = "region", key = "#id")
+    @Cacheable(key = "#id")
     public Region getRegion(Long id) throws NotValidRegionException {
         return regionRepository.findById(id).orElseThrow(() -> new NotValidRegionException("해당하는 지역이 없습니다."));
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(key = "#address")
     public List<Region> findRegionByAddress (String address) {
         return regionRepository.findAllByAddress(address);
     }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/controller/ChatController.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.team5.secondhand.chat.bubble.controller;
 
 import com.team5.secondhand.chat.bubble.domain.ChatBubble;
+import com.team5.secondhand.chat.bubble.dto.request.ChatbubbleRequest;
 import com.team5.secondhand.chat.topic.service.RedisMessagePublisher;
 import com.team5.secondhand.chat.notification.service.SendChatNotificationUsecase;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +19,10 @@ class ChatController {
     private final ChannelTopic chatTopic;
 
     @MessageMapping("/message")
-    public void message(ChatBubble message, SimpMessageHeaderAccessor messageHeaderAccessor) {
+    public void message(ChatbubbleRequest message, SimpMessageHeaderAccessor messageHeaderAccessor) {
         messageHeaderAccessor.getSessionAttributes();
         log.debug("pub controller");
-        redisMessagePublisher.publish(chatTopic.getTopic(), message);
+        redisMessagePublisher.publish(chatTopic.getTopic(), message.toDomain());
     }
 
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/controller/ChatController.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/controller/ChatController.java
@@ -21,7 +21,6 @@ class ChatController {
     @MessageMapping("/message")
     public void message(ChatbubbleRequest message, SimpMessageHeaderAccessor messageHeaderAccessor) {
         messageHeaderAccessor.getSessionAttributes();
-        log.debug("pub controller");
         redisMessagePublisher.publish(chatTopic.getTopic(), message.toDomain());
     }
 

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
@@ -1,6 +1,7 @@
 package com.team5.secondhand.chat.bubble.domain;
 
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.PostConstruct;
 import lombok.*;
 
 import java.io.Serializable;
@@ -9,6 +10,8 @@ import java.time.Instant;
 @Getter
 @NoArgsConstructor
 public class ChatBubble implements Serializable {
+
+    private static AtomicLong basicId;
 
     private Long id;
     private String chatroomId;
@@ -27,6 +30,15 @@ public class ChatBubble implements Serializable {
         this.createdAt = createdAt;
     }
 
+    @PostConstruct
+    private void init() {
+        basicId = new AtomicLong(System.currentTimeMillis());
+    }
+
+    private static Long generateId() {
+        return basicId.getAndIncrement();
+    }
+
     private String generateCreatedAt(String time) {
         if (time == null) {
             return Instant.now().toString();
@@ -39,6 +51,7 @@ public class ChatBubble implements Serializable {
     }
 
     public void ready() {
+        this.id = generateId();
         this.createdAt = generateCreatedAt(createdAt);
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 @NoArgsConstructor
 public class ChatBubble implements Serializable {
 
-    private AtomicLong basicId;
+    private static AtomicLong basicId;
 
     private Long id;
     private String chatroomId;
@@ -30,12 +30,11 @@ public class ChatBubble implements Serializable {
         this.createdAt = createdAt;
     }
 
-    @PostConstruct
-    private void init() {
+    static {
         basicId = new AtomicLong(System.currentTimeMillis());
     }
 
-    private static Long generateId() {
+    private Long generateId() {
         return basicId.getAndIncrement();
     }
 

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
@@ -1,5 +1,6 @@
 package com.team5.secondhand.chat.bubble.domain;
 
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.*;
 
 import java.io.Serializable;

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 @NoArgsConstructor
 public class ChatBubble implements Serializable {
 
-    private static AtomicLong basicId;
+    private AtomicLong basicId;
 
     private Long id;
     private String chatroomId;

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/request/ChatbubbleRequest.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/request/ChatbubbleRequest.java
@@ -1,0 +1,20 @@
+package com.team5.secondhand.chat.bubble.dto.request;
+
+import com.team5.secondhand.chat.bubble.domain.ChatBubble;
+
+public class ChatbubbleRequest {
+
+    private String chatroomId;
+    private Long sender;
+    private Long receiver;
+    private String message;
+
+    public ChatBubble toDomain() {
+        return ChatBubble.builder()
+                .chatroomId(chatroomId)
+                .sender(sender)
+                .receiver(receiver)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/repository/ChatBubbleCache.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/repository/ChatBubbleCache.java
@@ -1,49 +1,65 @@
 package com.team5.secondhand.chat.bubble.repository;
 
 import com.team5.secondhand.chat.bubble.domain.ChatBubble;
+import com.team5.secondhand.global.util.RedisOperationsHelper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class ChatBubbleCache{
+public class ChatBubbleCache {
 
-//    private final RedisTemplate<String, ChatBubble> redisChatBubbleTemplate;
-//
-//    private long getStartIndex(Pageable page) {
-//        return (-1L * page.getPageSize() * page.getPageNumber()) - 1;
-//    }
-//
-//    private Slice<ChatBubble> getSlice(List<ChatBubble> messages, Pageable pageable) {
-//        boolean hasNext = false;
-//
-//        if (messages.size() > pageable.getPageSize()) {
-//            hasNext = true;
-//            messages.remove(pageable.getPageSize());
-//        }
-//
-//        return new SliceImpl<>(messages, pageable, hasNext);
-//    }
-//
-//    public Slice<ChatBubble> findAllByRoomId(String key, Pageable pageable) {
-//        ListOperations<String, ChatBubble> listOperations = redisChatBubbleTemplate.opsForList();
-//
-//        long startIndex = getStartIndex(pageable);
-//        long endIndex = startIndex - pageable.getPageSize();
-//
-//        List<ChatBubble> messages = listOperations.range(key, endIndex, startIndex);
-//        return getSlice(messages, pageable);
-//    }
-//
-//    public ChatBubble save(String key, ChatBubble chatBubble) {
-//        redisChatBubbleTemplate.opsForList().rightPush(key, chatBubble); // 캐시 저장
-//        return redisChatBubbleTemplate.opsForValue().get(key);
-//    }
+    private final RedisOperationsHelper operationsHelper;
+
+    private long getStartIndex(Pageable page) {
+        return (-1L * page.getPageSize() * page.getPageNumber());
+    }
+
+    private Slice<ChatBubble> getSlice(List<ChatBubble> messages, Pageable pageable) {
+        if (messages.isEmpty()) {
+            throw new IndexOutOfBoundsException("빈 페이지 입니다.");
+        }
+
+        if (messages.size() > pageable.getPageSize()) {
+            messages.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(
+                messages.subList(0, Math.min(pageable.getPageSize(), messages.size())), pageable,
+                pageable.getPageSize() < messages.size());
+    }
+
+    public Slice<ChatBubble> findAllByRoomId(String key, Pageable pageable) {
+
+        long startIndex = getStartIndex(pageable);
+        long endIndex = startIndex - pageable.getPageSize();
+
+        List<ChatBubble> messages = operationsHelper.getList(key, endIndex - 1, startIndex,
+                ChatBubble.class);
+
+        return getSlice(messages, pageable);
+    }
+
+    public List<ChatBubble> findAllByRoomId(String key) {
+        long size = operationsHelper.size(key);
+        return operationsHelper.getList(key, 0, size, ChatBubble.class);
+    }
+
+    public ChatBubble save(String key, ChatBubble chatBubble) {
+        operationsHelper.putToList(key, chatBubble);
+        return chatBubble;
+    }
+
+    public int getLastPage(String key, int pageSize) {
+        Long size = operationsHelper.size(key);
+        return (int) (size / pageSize);
+    }
+
+    public void clear(String key) {
+        operationsHelper.delete(key);
+    }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
@@ -27,9 +27,12 @@ public class ChatBubbleService {
     public Slice<ChatBubble> getChatBubbles(int page, String roomId) {
         String key = generateChatLogKey(roomId);
         Pageable pageable = PageRequest.of(page, chatBubbleProperties.getPageSize(), Sort.by("createdAt").ascending());
-        Slice<BubbleEntity> list = bubbleRepository.findAllByChatroomId(roomId, pageable);
-        //TODO service 로직 변경
-        return list.map(BubbleEntity::toDomain);
+        try {
+            return bubbleCache.findAllByRoomId(key, pageable);
+        } catch (IndexOutOfBoundsException e) {
+            Slice<BubbleEntity> list = bubbleRepository.findAllByChatroomId(roomId, pageable);
+            return list.map(BubbleEntity::toDomain);
+        }
     }
 
     public ChatBubble saveChatBubble(ChatBubble chatBubble) {

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
@@ -5,7 +5,7 @@ import com.team5.secondhand.chat.bubble.repository.ChatBubbleCache;
 import com.team5.secondhand.chat.bubble.repository.ChatBubbleRepository;
 import com.team5.secondhand.chat.bubble.repository.entity.BubbleEntity;
 import com.team5.secondhand.chat.bubble.event.ChatBubbleArrivedEvent;
-import com.team5.secondhand.global.properties.ChatBubbleProperties;
+import com.team5.secondhand.global.properties.ChatCacheProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatBubbleService {
     private final ChatBubbleRepository bubbleRepository;
     private final ChatBubbleCache bubbleCache;
-    private final ChatBubbleProperties chatBubbleProperties;
+    private final ChatCacheProperties chatBubbleProperties;
 
     @Transactional(readOnly = true)
     public Slice<ChatBubble> getChatBubbles(int page, String roomId) {
@@ -46,6 +46,6 @@ public class ChatBubbleService {
     }
 
     private String generateChatLogKey (String roomId) {
-        return String.format("%s%s:logs", chatBubbleProperties.getBucket(), roomId);
+        return String.format("%s%s:logs", chatBubbleProperties.getKey(), roomId);
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
@@ -37,8 +37,7 @@ public class ChatBubbleService {
 
     public ChatBubble saveChatBubble(ChatBubble chatBubble) {
         String key = generateChatLogKey(chatBubble.getChatroomId());
-        BubbleEntity bubble= bubbleRepository.save(BubbleEntity.fromDomain(chatBubble));
-        return bubble.toDomain();
+        return bubbleCache.save(key, chatBubble);
     }
 
     @Async

--- a/backend/src/main/java/com/team5/secondhand/chat/chatroom/repository/ChatroomMetaCache.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/chatroom/repository/ChatroomMetaCache.java
@@ -1,8 +1,10 @@
 package com.team5.secondhand.chat.chatroom.repository;
 
 import com.team5.secondhand.chat.chatroom.domain.Chatroom;
+import com.team5.secondhand.global.properties.ChatMetaInfoProperties;
+import com.team5.secondhand.global.util.RedisOperationsHelper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,21 +12,28 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class ChatroomMetaCache {
-    private final RedisTemplate<String, Chatroom> redisChatroomTemplate;
-    private final String MAIN_KEY = "meta:chatroom";
-
+    private final RedisOperationsHelper operationsHelper;
+    private final ChatMetaInfoProperties chatMetaInfoProperties;
 
     public Chatroom saveChatroom(String chatroomId, Chatroom chatroom) {
-        redisChatroomTemplate.opsForValue().set(generateKey(chatroomId), chatroom);
-        return redisChatroomTemplate.opsForValue().get(generateKey((chatroomId)));
+        operationsHelper.put(generateKey(chatroomId), chatroom, null);
+        return chatroom;
     }
 
     public Optional<Chatroom> findByChatroomId(String chatroomId) {
-       Chatroom chatroom = redisChatroomTemplate.opsForValue().get(generateKey((chatroomId)));
-        return Optional.ofNullable(chatroom);
+        Optional<Chatroom> chatroom = operationsHelper.get(generateKey(chatroomId), Chatroom.class);
+        return chatroom;
+    }
+
+    public List<Chatroom> findAll() {
+        return operationsHelper.getAll(generateKey("*"), Chatroom.class);
+    }
+
+    public void clear() {
+        operationsHelper.delete(generateKey("*"));
     }
 
     private String generateKey(String chatroomId) {
-        return String.format("%s:%s", MAIN_KEY, chatroomId);
+        return String.format("%s:%s", chatMetaInfoProperties.getMetaInfoKey(), chatroomId);
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/topic/service/RedisMessagePublisher.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/topic/service/RedisMessagePublisher.java
@@ -20,8 +20,7 @@ public class RedisMessagePublisher {
 
     @Transactional
     public void publish(String topic, ChatBubble message) {
-        log.debug("pub log : " +  message.toString() + "/ topic: " + topic);
-        message.ready();
+        message.ready(); // id, createdAt 설정
         redisTemplate.convertAndSend(topic, message);
 
         publisher.publishEvent(new ChatBubbleArrivedEvent(message));

--- a/backend/src/main/java/com/team5/secondhand/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/team5/secondhand/global/config/CacheConfig.java
@@ -1,20 +1,21 @@
 package com.team5.secondhand.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 
-import java.time.Duration;
-
-@Slf4j
 @Configuration
+@EnableCaching
 @RequiredArgsConstructor
 public class CacheConfig {
 
@@ -22,18 +23,29 @@ public class CacheConfig {
     private final ObjectMapper objectMapper;
 
     @Bean
-    public RedisCacheManager redisCacheManager() {
+    public CacheManager redisCacheManager() {
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(cacheConfiguration())
+                .cacheDefaults(defaultCacheConfiguration())
+                .withInitialCacheConfigurations(CacheConfigurations())
                 .build();
     }
 
-    @Bean
-    public RedisCacheConfiguration cacheConfiguration() {
-         return RedisCacheConfiguration.defaultCacheConfig()
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new JdkSerializationRedisSerializer()))
+    @Bean(name = "defaultCacheConfiguration")
+    public RedisCacheConfiguration defaultCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
                 .entryTtl(Duration.ofSeconds(3))
                 .disableCachingNullValues();
+    }
+
+    @Bean
+    public Map<String, RedisCacheConfiguration> CacheConfigurations() {
+        return Map.of(
+                CacheKey.MEMBER, defaultCacheConfiguration().entryTtl(Duration.ofSeconds(5)),
+                CacheKey.ITEM, defaultCacheConfiguration().entryTtl(Duration.ofSeconds(3)),
+                CacheKey.REGION, defaultCacheConfiguration().entryTtl(Duration.ofSeconds(100))
+        );
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/global/config/CacheKey.java
+++ b/backend/src/main/java/com/team5/secondhand/global/config/CacheKey.java
@@ -1,0 +1,8 @@
+package com.team5.secondhand.global.config;
+
+public interface CacheKey {
+    String MEMBER = "member";
+    String ITEM = "item";
+    String REGION = "region";
+    String CHAT = "chat";
+}

--- a/backend/src/main/java/com/team5/secondhand/global/properties/ChatCacheProperties.java
+++ b/backend/src/main/java/com/team5/secondhand/global/properties/ChatCacheProperties.java
@@ -7,7 +7,8 @@ import org.springframework.stereotype.Component;
 
 @Getter @Setter
 @Component
-@ConfigurationProperties(prefix = "chat.notification")
-public class ChatNotificationProperties {
-    private long timeOut;
+@ConfigurationProperties(prefix = "chat.bubble")
+public class ChatCacheProperties {
+    private String key;
+    private int pageSize;
 }

--- a/backend/src/main/java/com/team5/secondhand/global/properties/ChatMetaInfoProperties.java
+++ b/backend/src/main/java/com/team5/secondhand/global/properties/ChatMetaInfoProperties.java
@@ -5,10 +5,11 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-@Getter @Setter
+@Getter
+@Setter
 @Component
-@ConfigurationProperties(prefix = "const.bubble")
-public class ChatBubbleProperties {
-    private String bucket;
-    private int pageSize;
+@ConfigurationProperties(prefix = "chat.meta")
+public class ChatMetaInfoProperties {
+    private String metaInfoKey;
+    private String connectionKey;
 }

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -4,7 +4,10 @@ server:
     was: "3.38.162.177"
 chat:
   bubble:
-    bucket: "chatroom:"
+    key: "chatroom::bubble::"
     page-size: 25
   notification:
     time-out: 720000
+  meta:
+    meta-info-key: "chatroom::meta::"
+    connection-key:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  servlet:
+#    context-path: /api
 spring:
   profiles:
     active: prod

--- a/backend/src/test/java/com/team5/secondhand/FixtureFactory.java
+++ b/backend/src/test/java/com/team5/secondhand/FixtureFactory.java
@@ -8,6 +8,7 @@ public abstract class FixtureFactory {
     public static FixtureMonkey fixtureMonkey() {
         return FixtureMonkey.builder()
                 .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+                .defaultNotNull(true)
                 .build();
     }
 

--- a/backend/src/test/java/com/team5/secondhand/chat/bubble/domain/ChatBubbleTest.java
+++ b/backend/src/test/java/com/team5/secondhand/chat/bubble/domain/ChatBubbleTest.java
@@ -1,0 +1,64 @@
+package com.team5.secondhand.chat.bubble.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class ChatBubbleTest {
+
+    @Nested
+    @DisplayName("ChatBubble 객체 생성")
+    class ready {
+
+            @Test
+            @DisplayName("ChatBubble 객체 생성")
+            void createChatBubble() {
+                // given
+                ChatBubble chatBubble = ChatBubble.builder()
+                        .chatroomId("1")
+                        .sender(1L)
+                        .receiver(2L)
+                        .message("hello")
+                        .build();
+
+                // when
+                chatBubble.ready();
+
+                // then
+                assertNotNull(chatBubble.getId());
+                assertNotNull(chatBubble.getCreatedAt());
+            }
+
+            @Test
+            @DisplayName("ChatBubble 객체 생성시 연속된 id 생성")
+            void createChatBubbleWithContinuousId() {
+                // given
+                ChatBubble chatBubble1 = ChatBubble.builder()
+                        .chatroomId("1")
+                        .sender(1L)
+                        .receiver(2L)
+                        .message("hello")
+                        .build();
+                ChatBubble chatBubble2 = ChatBubble.builder()
+                        .chatroomId("1")
+                        .sender(1L)
+                        .receiver(2L)
+                        .message("hello")
+                        .build();
+
+                // when
+                chatBubble1.ready();
+                chatBubble2.ready();
+
+                log.info("chatBubble1.getId(): {}", chatBubble1.getId());
+                log.info("chatBubble2.getId(): {}", chatBubble2.getId());
+
+                // then
+                assertEquals(chatBubble1.getId() + 1, chatBubble2.getId());
+            }
+    }
+}

--- a/backend/src/test/java/com/team5/secondhand/integration/global/util/RedisOperationsHelperTest.java
+++ b/backend/src/test/java/com/team5/secondhand/integration/global/util/RedisOperationsHelperTest.java
@@ -122,10 +122,6 @@ class RedisOperationsHelperTest extends TestContainer {
         });
     }
 
-    @Test
-    void isExists() {
-    }
-
     @Nested
     @DisplayName("만료시간 테스트 - ")
     class setExpireTime {
@@ -134,12 +130,15 @@ class RedisOperationsHelperTest extends TestContainer {
         @DisplayName("만료 전 테스트")
         void setExpireTime_not_expired() {
             String key = "member::3";
-            long expire = 1;
+            long expire = 10;
 
             redisOperationsHelper.put(key, dewey, null);
             redisOperationsHelper.setExpireTime(key, expire);
 
-            assertThat(redisOperationsHelper.getExpireTime(key)).isLessThan(expire);
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(redisOperationsHelper.getExpireTime(key)).isGreaterThan(0);
+                softAssertions.assertThat(redisOperationsHelper.get(key, Member.class)).isNotEmpty();
+            });
         }
 
         @Test

--- a/backend/src/test/java/com/team5/secondhand/integration/repository/ChatBubbleCacheTest.java
+++ b/backend/src/test/java/com/team5/secondhand/integration/repository/ChatBubbleCacheTest.java
@@ -1,0 +1,211 @@
+package com.team5.secondhand.integration.repository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.team5.secondhand.TestContainer;
+import com.team5.secondhand.chat.bubble.domain.ChatBubble;
+import com.team5.secondhand.chat.bubble.repository.ChatBubbleCache;
+import com.team5.secondhand.integration.IntegrationTest;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@IntegrationTest
+class ChatBubbleCacheTest extends TestContainer {
+
+    @Autowired
+    ChatBubbleCache chatBubbleCache;
+
+    ChatBubble chatBubble;
+    String chatroomId = "test-room-01";
+
+    @BeforeEach
+    void setUp() {
+        chatBubble = fixtureMonkey().giveMeBuilder(ChatBubble.class)
+                .set("id", 1L)
+                .set("chatroomId", chatroomId)
+                .sample();
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatBubbleCache.clear(chatroomId);
+    }
+
+    @Nested
+    @DisplayName("findAllByRoomId 테스트 - ")
+    class findAllByRoomId {
+
+        @Test
+        @DisplayName("성공")
+        void findAllByRoomId_success() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.size()).isEqualTo(1);
+                softAssertions.assertThat(result.get(0).getId()).isEqualTo(chatBubble.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("데이터 없을 시 빈 리스트 반환")
+        void findAllByRoomId_success2() {
+            // given
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.size()).isEqualTo(0);
+            });
+        }
+
+        @Test
+        @DisplayName("데이터 전체를 모두 블러올 수 있다.")
+        void findAllByRoomId_success3() {
+            // given
+            List<ChatBubble> chatBubbles = fixtureMonkey().giveMe(ChatBubble.class, 100);
+            chatBubbles.forEach(chatBubble -> chatBubbleCache.save(chatroomId, chatBubble));
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.size()).isEqualTo(100);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByRoomId paging 테스트 - ")
+    class testFindAllByRoomId {
+
+        @Test
+        @DisplayName("페이징 수보다 적은 데이터 저장시 성공")
+        void findAllByRoomId_success() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+            List<ChatBubble> chatBubbles = fixtureMonkey().giveMe(ChatBubble.class, 10);
+            chatBubbles.forEach(chatBubble -> chatBubbleCache.save(chatroomId, chatBubble));
+            Pageable pageRequest = PageRequest.of(0, 25);
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId, pageRequest);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.getContent().size()).isEqualTo(11);
+                softAssertions.assertThat(result.getContent().get(0).getId())
+                        .isEqualTo(chatBubble.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("페이징 수보다 많은 데이터 저장시 첫번째 페이지 조회 성공")
+        void findAllByRoomId_success2() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+            List<ChatBubble> chatBubbles = fixtureMonkey().giveMe(ChatBubble.class, 30);
+            chatBubbles.forEach(chatBubble -> chatBubbleCache.save(chatroomId, chatBubble));
+            Pageable pageRequest = PageRequest.of(0, 25);
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId, pageRequest);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.getContent().size()).isEqualTo(25);
+                softAssertions.assertThat(result.getContent().stream()
+                        .anyMatch(e -> e.getMessage().equals(chatBubble.getMessage()))).isFalse();
+            });
+        }
+
+        @Test
+        @DisplayName("페이징 수보다 많은 데이터 저장시 두번째 페이지 조회 성공")
+        void findAllByRoomId_success3() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+            List<ChatBubble> chatBubbles = fixtureMonkey().giveMe(ChatBubble.class, 30);
+            chatBubbles.forEach(chatBubble -> chatBubbleCache.save(chatroomId, chatBubble));
+            Pageable pageRequest = PageRequest.of(1, 25);
+
+            // when
+            var result = chatBubbleCache.findAllByRoomId(chatroomId, pageRequest);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.getContent().size()).isEqualTo(6);
+                softAssertions.assertThat(result.getContent().stream()
+                        .anyMatch(e -> e.getMessage().equals(chatBubble.getMessage()))).isTrue();
+            });
+        }
+
+        @Test
+        @DisplayName("데이터가 없는 페이지를 조회했을 때 예외가 발생해야 한다.")
+        void findAllByRoomId_fail() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+            Pageable pageRequest = PageRequest.of(2, 25);
+
+            // then
+            assertThatThrownBy(() -> chatBubbleCache.findAllByRoomId(chatroomId, pageRequest))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+        }
+
+    }
+
+    @Nested
+    class getLastPage {
+
+        @Test
+        @DisplayName("성공")
+        void getLastPage_success() {
+            // given
+            List<ChatBubble> chatBubbles = fixtureMonkey().giveMe(ChatBubble.class, 30);
+            chatBubbles.forEach(chatBubble -> chatBubbleCache.save(chatroomId, chatBubble));
+
+            // when
+            var result = chatBubbleCache.getLastPage(chatroomId, 25);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result).isEqualTo(1);
+            });
+        }
+
+    }
+
+    @Nested
+    class clear {
+
+        @Test
+        @DisplayName("성공")
+        void clear_success() {
+            // given
+            chatBubbleCache.save(chatroomId, chatBubble);
+
+            // when
+            chatBubbleCache.clear(chatroomId);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(chatBubbleCache.findAllByRoomId(chatroomId).size())
+                        .isEqualTo(0);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- `ChatBubble` 도메인 cache 구현 및 테스트
- 서비스 레이어에 캐시 및 레포지토리 저장로직 구현

## Refs.
- #466
