### PR TITLE
SSE timeout 시 에러 & 채팅 목록 반환 로직 에러 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.19.1"
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation('org.testcontainers:mysql') //no version specified
+    // test await
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }
 
 clean {

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/domain/ChatBubble.java
@@ -1,18 +1,17 @@
 package com.team5.secondhand.chat.bubble.domain;
 
-import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.PostConstruct;
-import lombok.*;
-
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class ChatBubble implements Serializable {
 
-    private static AtomicLong basicId;
-
+    private static final AtomicLong basicId;
     private Long id;
     private String chatroomId;
     private Long sender;
@@ -21,7 +20,8 @@ public class ChatBubble implements Serializable {
     private String createdAt;
 
     @Builder
-    private ChatBubble(Long id, String chatroomId, Long sender, Long receiver, String message, String createdAt) {
+    private ChatBubble(Long id, String chatroomId, Long sender, Long receiver, String message,
+            String createdAt) {
         this.id = id;
         this.chatroomId = chatroomId;
         this.sender = sender;
@@ -45,7 +45,7 @@ public class ChatBubble implements Serializable {
         return time;
     }
 
-    public Boolean isSender(String memberId) {
+    public Boolean isSender(long memberId) {
         return this.sender.equals(memberId);
     }
 

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/BubbleSummary.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/BubbleSummary.java
@@ -23,7 +23,7 @@ public class BubbleSummary {
         this.createdAt = createdAt;
     }
 
-    public static BubbleSummary from(ChatBubble bubble, String memberId) {
+    public static BubbleSummary from(ChatBubble bubble, long memberId) {
         return BubbleSummary.builder()
                 .id(bubble.getId().toString())
                 .senderId(bubble.getSender())

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/ChatroomLog.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/ChatroomLog.java
@@ -2,6 +2,7 @@ package com.team5.secondhand.chat.bubble.dto.response;
 
 import com.team5.secondhand.application.member.dto.response.MemberDetails;
 import com.team5.secondhand.chat.bubble.domain.ChatBubble;
+import java.util.Comparator;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Slice;
@@ -25,6 +26,7 @@ public class ChatroomLog {
     public static ChatroomLog from(Slice<ChatBubble> chatBubbles, MemberDetails loginMember) {
         List<BubbleSummary> bubbleSummaries = chatBubbles.getContent().stream()
                 .map(e -> BubbleSummary.from(e, loginMember.getMemberId()))
+                .sorted(Comparator.comparing(BubbleSummary::getCreatedAt))
                 .collect(Collectors.toList());
 
         return ChatroomLog.builder()

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/ChatroomLog.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/dto/response/ChatroomLog.java
@@ -25,7 +25,7 @@ public class ChatroomLog {
 
     public static ChatroomLog from(Slice<ChatBubble> chatBubbles, MemberDetails loginMember) {
         List<BubbleSummary> bubbleSummaries = chatBubbles.getContent().stream()
-                .map(e -> BubbleSummary.from(e, loginMember.getMemberId()))
+                .map(e -> BubbleSummary.from(e, loginMember.getId()))
                 .sorted(Comparator.comparing(BubbleSummary::getCreatedAt))
                 .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/repository/ChatBubbleRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/repository/ChatBubbleRepository.java
@@ -11,7 +11,5 @@ public interface ChatBubbleRepository extends JpaRepository<BubbleEntity, Long> 
 
     Slice<BubbleEntity> findAllByChatroomId(String chatroomId, Pageable pageable);
 
-    List<BubbleEntity> findAllByChatroomIdOrderByIdDesc(String chatroomId);
-
     BubbleEntity findFirstByOrderByIdDesc();
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/bubble/service/ChatBubbleService.java
@@ -26,7 +26,7 @@ public class ChatBubbleService {
     @Transactional(readOnly = true)
     public Slice<ChatBubble> getChatBubbles(int page, String roomId) {
         String key = generateChatLogKey(roomId);
-        Pageable pageable = PageRequest.of(page, chatBubbleProperties.getPageSize(), Sort.by("createdAt").ascending());
+        Pageable pageable = PageRequest.of(page, chatBubbleProperties.getPageSize(), Sort.by("createdAt").descending());
         try {
             return bubbleCache.findAllByRoomId(key, pageable);
         } catch (IndexOutOfBoundsException e) {

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/domain/SseKey.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/domain/SseKey.java
@@ -31,7 +31,7 @@ public class SseKey {
         return String.format("%d_%d",memberId,createdAt.getEpochSecond());
     }
 
-    public boolean startsWith(String memberId) {
+    public boolean startsWith(long memberId) {
         return this.memberId.equals(memberId);
     }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
@@ -2,6 +2,7 @@ package com.team5.secondhand.chat.notification.repository;
 
 import com.team5.secondhand.chat.notification.domain.SseKey;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -10,6 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class InmemoryNotificationRepository implements NotificationRepository {

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-//TODO Redis로 변경
 @Repository
 @RequiredArgsConstructor
 public class InmemoryNotificationRepository implements NotificationRepository {
@@ -24,29 +23,23 @@ public class InmemoryNotificationRepository implements NotificationRepository {
     }
 
     @Override
-    public void deleteAllStartByWithId(String id) {
-        int regIdx = id.indexOf("_");
-        String prefix = id.substring(0, regIdx+1);
+    public void deleteAllStartByWithId(long id) {
         emitters.forEach((key, value) -> {
-            if (key.startsWith(prefix)) {
+            if (key.startsWith(id)) {
                 emitters.remove(key);
             }
         });
     }
 
     @Override
-    public Map<SseKey, SseEmitter> findAllStartById(String id) {
-        int regIdx = id.indexOf("_");
-        String prefix = id.substring(0, regIdx+1);
+    public Map<SseKey, SseEmitter> findAllStartById(long id) {
         return emitters.entrySet().stream()
-                .filter(e -> e.getKey().startsWith(prefix))
+                .filter(e -> e.getKey().startsWith(id))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override
-    public Optional<SseEmitter> findStartById(String id) {
-        int regIdx = id.indexOf("_");
-        String prefix = id.substring(0, regIdx+1);
+    public Optional<SseEmitter> findStartById(long id) {
         return emitters.entrySet().stream()
                 .filter(e -> e.getKey().startsWith(id))
                 .map(Map.Entry::getValue)

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/repository/InmemoryNotificationRepository.java
@@ -45,4 +45,9 @@ public class InmemoryNotificationRepository implements NotificationRepository {
                 .map(Map.Entry::getValue)
                 .findAny();
     }
+
+    @Override
+    public void deleteById(SseKey sseId) {
+        emitters.remove(sseId);
+    }
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/repository/NotificationRepository.java
@@ -11,6 +11,5 @@ public interface NotificationRepository {
     void deleteAllStartByWithId(long id);
     Map<SseKey, SseEmitter> findAllStartById(long id);
     Optional<SseEmitter> findStartById(long id);
-
     void deleteById(SseKey sseId);
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/repository/NotificationRepository.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 
 public interface NotificationRepository {
     SseEmitter save(SseKey id, SseEmitter sseEmitter);
-    void deleteAllStartByWithId(String id);
-    Map<SseKey, SseEmitter> findAllStartById(String id);
-    Optional<SseEmitter> findStartById(String id);
+    void deleteAllStartByWithId(long id);
+    Map<SseKey, SseEmitter> findAllStartById(long id);
+    Optional<SseEmitter> findStartById(long id);
+
+    void deleteById(SseKey sseId);
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationEventListener.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationEventListener.java
@@ -1,0 +1,24 @@
+package com.team5.secondhand.chat.notification.service;
+
+import com.team5.secondhand.chat.bubble.event.ChatNotificationEvent;
+import com.team5.secondhand.chat.notification.dto.ChatNotification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class NotificationEventListener {
+
+    private final SendChatNotificationUsecase sendChatNotificationUsecase;
+
+    @Async
+    @EventListener
+    public void getChatBubble(ChatNotificationEvent event) {
+        Long receiverId = event.getChatBubble().getReceiver();
+        sendChatNotificationUsecase.sendChatNotificationToMember(receiverId, event.getChatroom(),
+                ChatNotification.of(event.getChatBubble(), event.getChatroom()));
+    }
+
+}

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
@@ -75,7 +75,11 @@ public class NotificationService implements SendChatNotificationUsecase {
     public void sendChatNotificationToMember(Long id, Chatroom chatroom,
             ChatNotification chatNotification) {
         SseEmitter sseEmitter = notificationRepository.findStartById(id)
-                .orElseThrow(() -> new NoSuchElementException("상대방이 접속중이 아닙니다."));
+                .orElseThrow(() -> {
+                    log.debug("👀 상대방이 접속중이 아닙니다.");
+                    //TODO message cache 처리
+                    throw new NoSuchElementException();
+                });
         if (chatroom.hasPaticipant(id)) {
             sendToClient(sseEmitter, id, chatNotification);
         }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
@@ -1,12 +1,16 @@
 package com.team5.secondhand.chat.notification.service;
 
+import com.team5.secondhand.chat.bubble.event.ChatNotificationEvent;
 import com.team5.secondhand.chat.chatroom.domain.Chatroom;
 import com.team5.secondhand.chat.notification.domain.SseEvent;
 import com.team5.secondhand.chat.notification.domain.SseKey;
 import com.team5.secondhand.chat.notification.dto.ChatNotification;
 import com.team5.secondhand.chat.notification.repository.NotificationRepository;
-import com.team5.secondhand.chat.bubble.event.ChatNotificationEvent;
 import com.team5.secondhand.global.properties.ChatNotificationProperties;
+import java.io.IOException;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -14,11 +18,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Map;
-import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -32,32 +31,35 @@ public class NotificationService implements SendChatNotificationUsecase {
     public SseEmitter subscribe(Long id, String lastEventId, HttpServletResponse response) {
         SseKey sseId = SseKey.of(id);
 
-        SseEmitter emitter = notificationRepository.save(sseId, new SseEmitter(notificationProperties.getTimeOut()));
+        SseEmitter emitter = notificationRepository.save(sseId,
+                new SseEmitter(notificationProperties.getTimeOut()));
         response.setHeader("X-Accel-Buffering", "no");
         response.setHeader("Last-Event-ID", sseId.getKey());
 
-        emitter.onCompletion(() -> onStatusCallback("SSE onCompletion", id));
+        emitter.onCompletion(() -> {
+            log.info("SSE onCompletion = {}", id);
+            notificationRepository.deleteById(sseId);
+        });
         emitter.onTimeout(() -> {
-            onStatusCallback("SSE onTimeout", id);
+            log.info("SSE onTimeout = {}", id);
             emitter.complete();
         });
-        emitter.onError(e -> onStatusCallback("SSE onError = " + e.getMessage(), id));
+        emitter.onError(e -> {
+            log.info("SSE onError = {}", id);
+            emitter.complete();
+        });
 
         sendToClient(emitter, id, String.format("connected successfully member key : %s", id));
 
         if (!lastEventId.isEmpty()) {
-            Map<SseKey, SseEmitter> events = notificationRepository.findAllStartById(id+"_");
+            Map<SseKey, SseEmitter> events = notificationRepository.findAllStartById(id);
             events.entrySet().stream()
                     .filter(entry -> lastEventId.compareTo(entry.getKey().getKey()) < 0)
-                    .forEach(entry -> sendToClient(emitter, entry.getKey().getMemberId(), entry.getValue())); //클라이언트가 연결을 끊기 전까지 받지 못한 새로운 이벤트를 보내준다.
+                    .forEach(entry -> sendToClient(emitter, entry.getKey().getMemberId(),
+                            entry.getValue())); //클라이언트가 연결을 끊기 전까지 받지 못한 새로운 이벤트를 보내준다.
         }
 
         return emitter;
-    }
-
-    public void onStatusCallback(String message, Long id) {
-        log.info(message);
-        notificationRepository.deleteAllStartByWithId(id +"_");
     }
 
     private void sendToClient(SseEmitter emitter, Long id, Object data) {
@@ -72,24 +74,21 @@ public class NotificationService implements SendChatNotificationUsecase {
     }
 
     @Override
-    public void sendChatNotificationToMember(Long id, Chatroom chatroom, ChatNotification chatNotification) {
-        try {
-            SseEmitter sseEmitter = notificationRepository.findStartById(id+"_").orElseThrow(() -> new NoSuchElementException("상대방이 접속중이 아닙니다."));
-            if (chatroom.hasPaticipant(id)) {
-                sendToClient(sseEmitter, id, chatNotification);
-            }
-        } catch (NoSuchElementException e) {
-            log.info(e.getMessage());
+    public void sendChatNotificationToMember(Long id, Chatroom chatroom,
+            ChatNotification chatNotification) {
+        SseEmitter sseEmitter = notificationRepository.findStartById(id)
+                .orElseThrow(() -> new NoSuchElementException("상대방이 접속중이 아닙니다."));
+        if (chatroom.hasPaticipant(id)) {
+            sendToClient(sseEmitter, id, chatNotification);
         }
-
     }
 
-    //TODO Transaction 관련된 문제가 나지는 않을까?
     @Async
     @EventListener
-    public void getChatBubble (ChatNotificationEvent event) {
+    public void getChatBubble(ChatNotificationEvent event) {
         Long receiverId = event.getChatBubble().getReceiver();
-        sendChatNotificationToMember(receiverId, event.getChatroom(), ChatNotification.of(event.getChatBubble(), event.getChatroom()));
+        sendChatNotificationToMember(receiverId, event.getChatroom(),
+                ChatNotification.of(event.getChatBubble(), event.getChatroom()));
     }
 
 }

--- a/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/team5/secondhand/chat/notification/service/NotificationService.java
@@ -85,12 +85,4 @@ public class NotificationService implements SendChatNotificationUsecase {
         }
     }
 
-    @Async
-    @EventListener
-    public void getChatBubble(ChatNotificationEvent event) {
-        Long receiverId = event.getChatBubble().getReceiver();
-        sendChatNotificationToMember(receiverId, event.getChatroom(),
-                ChatNotification.of(event.getChatBubble(), event.getChatroom()));
-    }
-
 }

--- a/backend/src/main/java/com/team5/secondhand/global/properties/ChatNotificationProperties.java
+++ b/backend/src/main/java/com/team5/secondhand/global/properties/ChatNotificationProperties.java
@@ -9,5 +9,6 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "chat.notification")
 public class ChatNotificationProperties {
+    private String key;
     private long timeOut;
 }

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -7,6 +7,7 @@ chat:
     key: "chatroom::bubble::"
     page-size: 25
   notification:
+    key: "member::notification::"
     time-out: 720000
   meta:
     meta-info-key: "chatroom::meta::"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,3 @@
-server:
-  servlet:
-#    context-path: /api
 spring:
   profiles:
     active: prod

--- a/backend/src/test/java/com/team5/secondhand/integration/chat/bubble/domain/ChatBubbleTest.java
+++ b/backend/src/test/java/com/team5/secondhand/integration/chat/bubble/domain/ChatBubbleTest.java
@@ -1,7 +1,8 @@
-package com.team5.secondhand.chat.bubble.domain;
+package com.team5.secondhand.integration.chat.bubble.domain;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.team5.secondhand.chat.bubble.domain.ChatBubble;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/backend/src/test/java/com/team5/secondhand/integration/chat/notification/repository/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/team5/secondhand/integration/chat/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.team5.secondhand.integration.chat.notification.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.team5.secondhand.FixtureFactory;
+import com.team5.secondhand.chat.notification.domain.SseKey;
+import com.team5.secondhand.chat.notification.repository.NotificationRepository;
+import com.team5.secondhand.integration.IntegrationTest;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@IntegrationTest
+@DisplayName("NotificationRepository 통합 테스트")
+class NotificationRepositoryTest extends FixtureFactory {
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    SseKey sseKey;
+    SseEmitter sseEmitter;
+
+    @BeforeEach
+    void setUp() {
+        sseKey = SseKey.of(1L);
+        sseEmitter = new SseEmitter();
+    }
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAllStartByWithId(1L);
+    }
+
+    @Nested
+    @DisplayName("save 를 시행할 때, ")
+    class save {
+
+        @Test
+        @DisplayName("SseEmitter를 저장할 수 있다.")
+        void save() {
+            // given
+            Map<SseKey, SseEmitter> allStartById = notificationRepository.findAllStartById(
+                    sseKey.getMemberId());
+            int before = allStartById.size();
+            // when
+            SseEmitter savedSseEmitter = notificationRepository.save(sseKey, sseEmitter);
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(savedSseEmitter).isEqualTo(sseEmitter);
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(sseKey.getMemberId()).size())
+                        .isEqualTo(before + 1);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAllStartByWithId 를 시행할 때, ")
+    class deleteAllStartByWithId {
+
+        @Test
+        @DisplayName("SseEmitter를 삭제할 수 있다.")
+        void deleteAllStartByWithId() {
+            // given
+            notificationRepository.save(sseKey, sseEmitter);
+            // when
+            notificationRepository.deleteAllStartByWithId(sseKey.getMemberId());
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(sseKey.getMemberId()).size())
+                        .isEqualTo(0);
+            });
+        }
+
+        @Test
+        @DisplayName("특정 key로 시작하는 SseEmitter를 삭제할 수 있다.")
+        void deleteAllStartByWithId2() {
+            // given
+            notificationRepository.save(sseKey, sseEmitter);
+            notificationRepository.save(SseKey.of(2L), sseEmitter);
+            // when
+            notificationRepository.deleteAllStartByWithId(sseKey.getMemberId());
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(sseKey.getMemberId()).size())
+                        .isEqualTo(0);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllStartById 를 시행할 때, ")
+    class findAllStartById {
+        @Test
+        @DisplayName("특정 key로 시작하는 SseEmitter를 찾을 수 있다.")
+        void findAllStartById() {
+            // given
+            notificationRepository.save(sseKey, sseEmitter);
+            notificationRepository.save(SseKey.of(2L), sseEmitter);
+            // when
+            Map<SseKey, SseEmitter> allStartById = notificationRepository.findAllStartById(
+                    sseKey.getMemberId());
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(allStartById.size()).isEqualTo(1);
+                softAssertions.assertThat(allStartById.get(sseKey)).isEqualTo(sseEmitter);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("findStartById 를 시행할 때, ")
+    class findStartById {
+        @Test
+        @DisplayName("특정 key로 시작하는 SseEmitter를 찾을 수 있다.")
+        void findStartById() {
+            // given
+            notificationRepository.save(sseKey, sseEmitter);
+            notificationRepository.save(SseKey.of(2L), sseEmitter);
+            // when
+            SseEmitter startById = notificationRepository.findStartById(sseKey.getMemberId()).get();
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(startById).isEqualTo(sseEmitter);
+            });
+        }
+    }
+}

--- a/backend/src/test/java/com/team5/secondhand/integration/chat/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/team5/secondhand/integration/chat/notification/service/NotificationServiceTest.java
@@ -1,0 +1,133 @@
+package com.team5.secondhand.integration.chat.notification.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.team5.secondhand.FixtureFactory;
+import com.team5.secondhand.chat.notification.domain.SseKey;
+import com.team5.secondhand.chat.notification.repository.NotificationRepository;
+import com.team5.secondhand.chat.notification.service.NotificationService;
+import com.team5.secondhand.global.properties.ChatNotificationProperties;
+import com.team5.secondhand.integration.IntegrationTest;
+import java.time.Duration;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@IntegrationTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationService 통합 테스트")
+class NotificationServiceTest extends FixtureFactory {
+
+    @Autowired
+    NotificationService notificationService;
+    @Autowired
+    NotificationRepository notificationRepository;
+    @Autowired
+    ChatNotificationProperties chatNotificationProperties;
+    @Spy
+    HttpServletResponse httpServletResponse;
+
+    String sseKey = "1_1239213";
+    long id = 1L;
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAllStartByWithId(id);
+    }
+
+    @Nested
+    @DisplayName("subscribe 를 시행할 때, ")
+    class subscribe {
+        @Test
+        @DisplayName("SseEmitter를 저장할 수 있다.")
+        void subscribe() {
+            // when
+            notificationService.subscribe(1L, null, httpServletResponse);
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(id).size())
+                        .isEqualTo(1);
+            });
+        }
+
+        @Test
+        @DisplayName("SseEmitter가 Complete 되면 삭제한다.")
+        void subscribeAndComplete() {
+            // given
+            Map<SseKey, SseEmitter> before = notificationRepository.findAllStartById(id);
+            SseEmitter sseEmitter = notificationService.subscribe(1L, null, httpServletResponse);
+
+            // when
+            sseEmitter.complete();
+
+            // then
+            await().untilAsserted(() -> {
+                log.debug("after: {}", notificationRepository.findAllStartById(id).size());
+                assertEquals(before.size()-1, notificationRepository.findAllStartById(id).size());
+            });
+
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(id).size())
+                        .isEqualTo(0);
+            });
+        }
+
+        @Test
+        @DisplayName("SseEmitter가 Error 되면 삭제한다.")
+        void subscribeAndError() {
+            // given
+            // when
+            SseEmitter sseEmitter = notificationService.subscribe(1L, null, httpServletResponse);
+            sseEmitter.completeWithError(new RuntimeException());
+
+            await().untilAsserted(() -> {
+                log.debug("after: {}", notificationRepository.findAllStartById(id).size());
+                assertEquals(0, notificationRepository.findAllStartById(id).size());
+            });
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(id).size())
+                        .isEqualTo(0);
+            });
+        }
+
+        @Test
+        @DisplayName("SseEmitter가 Timeout 되면 삭제한다.")
+        void subscribeAndTimeout() {
+            // given
+            // when
+            SseEmitter sseEmitter = notificationService.subscribe(1L, "", httpServletResponse);
+
+            await().atLeast(Duration.ofMillis(chatNotificationProperties.getTimeOut()));
+
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(sseEmitter.getTimeout()).isLessThan(0L);
+                softAssertions.assertThat(
+                                notificationRepository.findAllStartById(id).size())
+                        .isEqualTo(0);
+            });
+        }
+    }
+
+    @Test
+    void sendChatNotificationToMember() {
+    }
+}

--- a/backend/src/test/java/com/team5/secondhand/unit/domian/ChatRoomTest.java
+++ b/backend/src/test/java/com/team5/secondhand/unit/domian/ChatRoomTest.java
@@ -1,4 +1,4 @@
-package com.team5.secondhand.integration.chatroom.domian;
+package com.team5.secondhand.unit.domian;
 
 import com.team5.secondhand.application.chatroom.domian.Chatroom;
 import com.team5.secondhand.application.chatroom.domian.ChatroomStatus;


### PR DESCRIPTION
- SSE timeout 시 emitter가 삭제되지 않았던 문제 해결하였습니다.
- 채팅 목록 반환시 날짜 오름차순이던 정렬 로직 변경